### PR TITLE
Corepack Support & Dependabot Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     "release:patch": "npm version patch --no-git-tag-version && npm run release",
     "release:minor": "npm version minor --no-git-tag-version && npm run release",
     "release:major": "npm version major --no-git-tag-version && npm run release"
-  }
+  },
+  "packageManager": "pnpm@9.4.0"
 }


### PR DESCRIPTION
This PR adds packageManager field to the package.json file of the project in order to support [Corepack](https://nodejs.org/api/corepack.html). This also fixes the issue with Dependabot version upgrades resetting the pnpm lockfile to v6.